### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ https://sutara79.github.io/jquery.add-input-area/
 - [npm](https://www.npmjs.com/package/jquery.add-input-area): `npm i jquery.add-input-area`
 - [CDN (jsDelivr)](http://www.jsdelivr.com/projects/jquery.add-input-area):
     ```javascript
-    <script src="https://cdn.jsdelivr.net/jquery.add-input-area/4.9.0/jquery.add-input-area.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery.add-input-area@4.9.1/dist/jquery.add-input-area.min.js"></script>
     ```
   You can load jQuery and this plugin with single HTTP request.  
   See [jsDelivr's document](https://github.com/jsdelivr/jsdelivr#load-multiple-files-with-single-http-request)
     ```javascript
-    <script src="https://cdn.jsdelivr.net/g/jquery@3.2.1,jquery.add-input-area@4.9.0"></script>
+    <script src="https://cdn.jsdelivr.net/combine/npm/jquery@3.2.1,npm/jquery.add-input-area@4.9.1"></script>
     ```
 
 ## Usage


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jquery.add-input-area.

Feel free to ping me if you have any questions regarding this change.